### PR TITLE
chore: get testcontainers working with custom mix task

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,21 +20,6 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:latest
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Elixir
@@ -51,4 +36,4 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
     - name: Run tests
-      run: mix test
+      run: mix testcontainers_test

--- a/README.md
+++ b/README.md
@@ -80,9 +80,8 @@ erDiagram
 
 To start your Phoenix server:
 
+  * Run `docker run --name some-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres`
   * Run `mix setup`
-  * Run `docker run --name some-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgre` (testcontainers for elixir doesnt have support for multiple repos yet ...)
-  * Run `mix reset` to install and setup dependencies
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000/itineraries`](http://localhost:4000/itineraries) from your browser.

--- a/lib/mix/tasks/testcontainers_test.ex
+++ b/lib/mix/tasks/testcontainers_test.ex
@@ -1,0 +1,34 @@
+# lib/mix/tasks/custom_test.ex
+defmodule Mix.Tasks.TestcontainersTest do
+  use Mix.Task
+  alias Testcontainers.PostgresContainer
+
+  @shortdoc "Runs tests with a Postgres container"
+  def run(_) do
+    Application.ensure_all_started(:tesla)
+    Application.ensure_all_started(:hackney)
+
+    # Start Testcontainers
+    {:ok, _} = Testcontainers.start_link()
+
+    # Configure and start a Postgres container
+    config = PostgresContainer.new()
+    {:ok, container} = Testcontainers.start_container(config)
+
+    # Get the connection URL
+    app_database_url = "postgres://test:test@#{Testcontainers.get_host()}:#{PostgresContainer.port(container)}/app_test"
+    cmd_database_url = "postgres://test:test@#{Testcontainers.get_host()}:#{PostgresContainer.port(container)}/cmd_test"
+
+    try do
+      {output, exit_code} = System.cmd("mix", ["test"], env: [{"APP_DATABASE_URL", app_database_url}, {"COMMANDED_DATABASE_URL", cmd_database_url}])
+      if exit_code != 0 do
+        IO.puts(output)
+        raise "\u274c Tests failed"
+      end
+      IO.puts("\u2705 Tests passed")
+    after
+      # Stop the container
+      Testcontainers.stop_container(container.container_id)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,8 @@ defmodule JourniPlan.MixProject do
       {:commanded, "~> 1.4"},
       {:commanded_eventstore_adapter, "~> 1.4"},
       {:commanded_ecto_projections, "~> 1.4"},
-      {:exconstructor, "~> 1.2"}
+      {:exconstructor, "~> 1.2"},
+      {:testcontainers, "~> 1.8.4", only: [:dev, :test]}
     ]
   end
 
@@ -76,10 +77,10 @@ defmodule JourniPlan.MixProject do
   defp aliases do
     [
       setup: [
-	"deps.get",
-	"ecto.setup",
-	# "assets.setup",
-	"assets.build"
+        "deps.get",
+        "reset",
+        "assets.setup",
+        "assets.build"
       ],
       "event_store.init": ["event_store.drop", "event_store.create", "event_store.init"],
       "ecto.init": ["ecto.drop", "ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],


### PR DESCRIPTION
Run tests with testcontainers for elixir. Requires a bit of hacking. since commanded "needs"/"uses" its own database.
Im the maintainer of said testcontainers library so maybe this will trickle upstream ...